### PR TITLE
Redesign site with sleek, typographic, dark-mode aesthetic

### DIFF
--- a/src/components/BlogNavigation.astro
+++ b/src/components/BlogNavigation.astro
@@ -1,8 +1,20 @@
 ---
-import Button from './Button.astro';
+const tabs = [
+    { href: "/blog", label: "Overview", exact: true },
+    { href: "/blog/posts", label: "All Posts" },
+    { href: "/blog/tags", label: "Tags" },
+];
+const path = Astro.url.pathname;
+const active = (t: { href: string; exact?: boolean }) =>
+    t.exact ? path === t.href || path === t.href + "/" : path.startsWith(t.href);
 ---
-<div class="flex">
-    <Button link="/blog">Blog Home</Button>
-    <Button link="/blog/posts">All Posts</Button>
-    <Button link="/blog/tags">Tags</Button>
-</div>
+{tabs.map((t) => (
+    <a
+        href={t.href}
+        aria-current={active(t) ? "page" : undefined}
+        class={`whitespace-nowrap rounded-full px-3.5 py-1.5 font-mono text-[12px] uppercase tracking-wide transition-colors
+            ${active(t) ? "bg-ink text-bg" : "text-muted hover:bg-elevated hover:text-ink"}`}
+    >
+        {t.label}
+    </a>
+))}

--- a/src/components/BlogNavigation.astro
+++ b/src/components/BlogNavigation.astro
@@ -1,12 +1,13 @@
 ---
 const tabs = [
-    { href: "/blog", label: "Overview", exact: true },
+    { href: "/blog", label: "Overview" },
     { href: "/blog/posts", label: "All Posts" },
     { href: "/blog/tags", label: "Tags" },
 ];
-const path = Astro.url.pathname;
-const active = (t: { href: string; exact?: boolean }) =>
-    t.exact ? path === t.href || path === t.href + "/" : path.startsWith(t.href);
+const path = Astro.url.pathname.replace(/\/$/, "");
+// Each tab is only active on its own index page — detail pages
+// (/blog/posts/<slug>, /blog/tags/<tag>) highlight nothing.
+const active = (t: { href: string }) => path === t.href;
 ---
 {tabs.map((t) => (
     <a

--- a/src/components/BlogPostItem.astro
+++ b/src/components/BlogPostItem.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import { getPostBanner } from "@helpers/posts";
+import "@helpers/utility";
 
 type Props = {
     post: CollectionEntry<"blog">
@@ -8,22 +9,38 @@ type Props = {
 }
 
 const { post, display = "full" } = Astro.props;
+const banner = post.data.image?.url ?? await getPostBanner(post);
+const date = post.data.date.toISOString().split('T')[0];
+const readableDate = post.data.date.toFormattedDateString();
+const primaryTag = post.data.tags?.[0];
 ---
-<div transition:name={post.slug} class="font-body">
-    <a
-    class="flex flex-col justify-center rounded-md p-2 m-2 hover:shadow-lg shadow-md transition-all duration-300 group bg-cover hover:bg-bottom" 
-    style={`background-image: url(${post.data.image?.url ?? await getPostBanner(post) });`}
-    href={`/blog/posts/${post.slug}`}>
-    <div class="bg-white bg-opacity-80 backdrop-blur-sm p-2 mt-16 rounded-sm group-hover:outline outline-primary">
-        <div class="grid grid-cols-[1fr_auto] justify-between">
-            <h1 transition:name={`title-${post.slug}`} class="text-lg lg:text-xl font-bold">{post.data.title}</h1>
-            <p class="text-sm">{post.data.date.toISOString().split('T')[0]}</p>
-        </div>    
-            {display == "full" && (
-            <div class="relative">
-                <h3 class="px-1 overflow-clip text-md text-slate-700">{post.data.description}</h3>
-            </div>
-            )}
+<a
+    href={`/blog/posts/${post.slug}`}
+    transition:name={post.slug}
+    data-reveal
+    class="group grid grid-cols-[1fr] gap-4 rounded-2xl border border-transparent p-3 transition-all duration-300
+           hover:border-line hover:bg-surface sm:grid-cols-[auto_1fr] sm:gap-5"
+>
+    <div class="relative hidden h-24 w-40 shrink-0 overflow-hidden rounded-xl border border-line sm:block">
+        <div
+            style={`background-image: url(${banner});`}
+            class="absolute inset-0 bg-cover bg-center transition-transform duration-500 group-hover:scale-110"
+        ></div>
     </div>
-    </a>
-</div>
+
+    <div class="flex min-w-0 flex-col justify-center">
+        <div class="mb-1.5 flex items-center gap-3 font-mono text-[11px] uppercase tracking-wide text-faint">
+            <time datetime={date}>{readableDate}</time>
+            {primaryTag && (<><span class="text-line">/</span><span class="text-accent">{primaryTag}</span></>)}
+        </div>
+        <h3
+            transition:name={`title-${post.slug}`}
+            class="font-display text-lg font-semibold leading-snug tracking-tight text-ink transition-colors group-hover:text-accent sm:text-xl"
+        >
+            {post.data.title}
+        </h3>
+        {display === "full" && (
+            <p class="mt-1.5 line-clamp-2 text-sm leading-relaxed text-muted">{post.data.description}</p>
+        )}
+    </div>
+</a>

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -10,13 +10,18 @@ type Props = {
 }
 
 const { link, classes, inverted = false, external = false } = Astro.props;
-const colouring = inverted ? "bg-primary hover:bg-page text-page hover:text-black" : "bg-page outline-primary outline outline-1 hover:bg-primary text-black hover:text-page"
+
+const base = "group inline-flex items-center gap-2 rounded-full px-4 py-2 font-mono text-[13px] uppercase tracking-wide transition-all duration-200";
+const colouring = inverted
+    ? "bg-ink text-bg hover:bg-accent"
+    : "border border-line text-ink hover:border-accent hover:text-accent";
 ---
-<a 
-    class={mergeClasses("inline-block m-1 py-1 px-2 text-lg rounded-sm transition-all h-9", colouring, classes ?? "")}
+<a
+    class={mergeClasses(base, colouring, classes ?? "")}
     href={link}
     rel="prefetch"
     target={external ? "_blank" : "_self"}
 >
     <slot />
+    <span aria-hidden="true" class="transition-transform duration-200 group-hover:translate-x-1">→</span>
 </a>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,18 +1,48 @@
 ---
-const platform = "github";
-const username = "tvandinther";
+const year = new Date().getFullYear();
+
+const nav = [
+    { href: "/projects", label: "Projects" },
+    { href: "/blog", label: "Writing" },
+    { href: "/about", label: "About" },
+];
+
+const social = [
+    { href: "https://github.com/tvandinther", label: "GitHub" },
+    { href: "https://www.linkedin.com/in/tvandinther/", label: "LinkedIn" },
+];
 ---
-<footer class="w-screen bg-page sticky h-8 bottom-0 z-50 [&.hide]:-bottom-8 transition-[bottom]">
-    <div class="px-8 py-1 bg-primary text-page">
-        <p>Learn more about my projects on <a class="underline" target="_blank" href={`https://www.${platform}.com/${username}`}>{platform}</a>!</p>
+<footer class="mt-24 border-t border-line bg-surface/40">
+    <div class="mx-auto max-w-content px-5 py-14 sm:px-8 lg:px-10">
+        <div class="flex flex-col gap-10 md:flex-row md:items-end md:justify-between">
+            <div>
+                <a href="/" class="flex items-baseline gap-px font-display text-3xl font-bold tracking-tightest text-ink">
+                    <span>mioi</span><span class="text-accent">.</span><span class="text-faint">io</span>
+                </a>
+                <p class="mt-3 max-w-sm text-sm leading-relaxed text-muted">
+                    Miscellaneous items of interest — the projects, writing and ideas of Tom van Dinther, platform &amp; DevOps engineer.
+                </p>
+            </div>
+
+            <div class="flex gap-16">
+                <nav class="flex flex-col gap-2">
+                    <span class="mb-1 font-mono text-[11px] uppercase tracking-widest text-faint">Site</span>
+                    {nav.map((l) => (
+                        <a href={l.href} class="text-sm text-muted transition-colors hover:text-accent">{l.label}</a>
+                    ))}
+                </nav>
+                <nav class="flex flex-col gap-2">
+                    <span class="mb-1 font-mono text-[11px] uppercase tracking-widest text-faint">Elsewhere</span>
+                    {social.map((l) => (
+                        <a href={l.href} target="_blank" rel="noopener" class="text-sm text-muted transition-colors hover:text-accent">{l.label} ↗</a>
+                    ))}
+                </nav>
+            </div>
+        </div>
+
+        <div class="mt-12 flex flex-col gap-2 border-t border-line pt-6 font-mono text-[11px] uppercase tracking-wide text-faint sm:flex-row sm:items-center sm:justify-between">
+            <span>© {year} Tom van Dinther</span>
+            <span>Built with Astro · Hosted on Cloudflare</span>
+        </div>
     </div>
 </footer>
-<script is:inline>
-    (function() {var p = window.scrollY;
-    const h = document.querySelector("footer");
-    window.addEventListener("scroll", () => {
-      const c = window.scrollY;
-      if (window.scrollHiding.footer) p < c ? h.classList.add("hide") : h.classList.remove("hide");
-      p = c;
-    })})();
-</script>

--- a/src/components/GlobalStyles.astro
+++ b/src/components/GlobalStyles.astro
@@ -1,10 +1,121 @@
+---
+// Global theme tokens + base styles. Imported once from BaseLayout.
+---
+<style is:global>
+    /* ---- Theme tokens (RGB channels for Tailwind <alpha-value>) ---- */
+    :root {
+        --bg: 250 249 246;        /* warm paper */
+        --surface: 255 255 255;
+        --elevated: 255 255 255;
+        --ink: 24 23 28;          /* near-black */
+        --muted: 92 90 98;
+        --faint: 142 140 150;
+        --line: 228 225 219;
+        --accent: 226 84 18;      /* refined vermilion */
+        --accent-soft: 245 196 173;
+        --accent-wash: 253 240 233;
+
+        --grid: 0 0 0;            /* hairline grid tint */
+        --glow: 226 84 18;
+
+        color-scheme: light;
+    }
+
+    html.dark {
+        --bg: 13 13 16;           /* ink black */
+        --surface: 20 20 24;
+        --elevated: 27 27 32;
+        --ink: 237 236 240;
+        --muted: 162 160 170;
+        --faint: 110 108 120;
+        --line: 40 40 47;
+        --accent: 255 122 69;     /* brighter for dark */
+        --accent-soft: 120 64 40;
+        --accent-wash: 36 24 18;
+
+        --grid: 255 255 255;
+        --glow: 255 122 69;
+
+        color-scheme: dark;
+    }
+
+    html {
+        scroll-behavior: smooth;
+        -webkit-text-size-adjust: 100%;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        html { scroll-behavior: auto; }
+        *, *::before, *::after {
+            animation-duration: 0.001ms !important;
+            animation-iteration-count: 1 !important;
+            transition-duration: 0.001ms !important;
+        }
+    }
+
+    body {
+        background-color: rgb(var(--bg));
+        color: rgb(var(--ink));
+        font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+        transition: background-color 0.4s ease, color 0.4s ease;
+    }
+
+    ::selection {
+        background-color: rgb(var(--accent) / 0.18);
+        color: rgb(var(--ink));
+    }
+
+    /* Subtle custom scrollbar */
+    * { scrollbar-width: thin; scrollbar-color: rgb(var(--line)) transparent; }
+    *::-webkit-scrollbar { width: 10px; height: 10px; }
+    *::-webkit-scrollbar-thumb {
+        background-color: rgb(var(--line));
+        border-radius: 999px;
+        border: 3px solid rgb(var(--bg));
+    }
+
+    /* ---- Scroll reveal ---- */
+    [data-reveal] {
+        opacity: 0;
+        transform: translateY(18px);
+        transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+                    transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+        transition-delay: var(--reveal-delay, 0ms);
+        will-change: opacity, transform;
+    }
+    [data-reveal].is-visible {
+        opacity: 1;
+        transform: none;
+    }
+    @media (prefers-reduced-motion: reduce) {
+        [data-reveal] { opacity: 1; transform: none; }
+    }
+
+    /* ---- Animated link underline utility ---- */
+    .link-underline {
+        background-image: linear-gradient(rgb(var(--accent)), rgb(var(--accent)));
+        background-size: 0% 1px;
+        background-position: 0 100%;
+        background-repeat: no-repeat;
+        transition: background-size 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+    .link-underline:hover { background-size: 100% 1px; }
+
+    /* Dotted grid backdrop helper */
+    .bg-dotgrid {
+        background-image: radial-gradient(rgb(var(--grid) / 0.10) 1px, transparent 1px);
+        background-size: 22px 22px;
+    }
+</style>
 <style is:global>
     @font-face {
         font-family: "Virgil";
         src: url("https://excalidraw.com/Virgil.woff2");
-      }
-      @font-face {
+    }
+    @font-face {
         font-family: "Cascadia";
         src: url("https://excalidraw.com/Cascadia.woff2");
-      }
+    }
 </style>

--- a/src/components/Hamburger.astro
+++ b/src/components/Hamburger.astro
@@ -1,24 +1,48 @@
 ---
 ---
-<div id="hamburger" class="cursor-pointer lg:hidden w-10 ml-auto group">
-    <span class="block h-1 my-2 bg-slate-400 rounded-full transition-all group-hover:bg-page [.open>&]:rotate-45 [.open>&]:translate-y-3"></span>
-    <span class="block h-1 mb-2 bg-slate-400 rounded-full transition-all group-hover:bg-page [.open>&]:-rotate-45"></span>
-    <span class="block h-1 mb-2 bg-slate-400 rounded-full transition-all group-hover:bg-page [.open>&]:opacity-0"></span>
-</div>
+<button id="hamburger" type="button" aria-label="Open menu" aria-expanded="false" class="group grid h-9 w-9 place-items-center lg:hidden">
+    <span class="relative block h-4 w-5">
+        <span class="absolute left-0 top-0 block h-0.5 w-5 rounded-full bg-ink transition-all duration-300 [.open_&]:top-1/2 [.open_&]:-translate-y-1/2 [.open_&]:rotate-45"></span>
+        <span class="absolute left-0 top-1/2 block h-0.5 w-5 -translate-y-1/2 rounded-full bg-ink transition-all duration-300 [.open_&]:opacity-0"></span>
+        <span class="absolute bottom-0 left-0 block h-0.5 w-5 rounded-full bg-ink transition-all duration-300 [.open_&]:bottom-1/2 [.open_&]:translate-y-1/2 [.open_&]:-rotate-45"></span>
+    </span>
+</button>
 <script>
-    (function() {
-        var o = false;
-        document.getElementById('hamburger')?.addEventListener('click', function() {
-            window.scrollHiding.header = o;
-            window.scrollHiding.footer = o;
-            document.getElementById('hamburger')?.classList.toggle('open');
-            document.getElementById('side-navigation')?.classList.toggle('open');
-            document.body.classList.toggle('overflow-hidden');
-            o = !o;
-        })
-
-        document.addEventListener('astro:after-swap', function() {
+    (function () {
+        function close(state: { open: boolean }) {
             document.getElementById('hamburger')?.classList.remove('open');
-        })
+            document.getElementById('hamburger')?.setAttribute('aria-expanded', 'false');
+            document.getElementById('side-navigation')?.classList.remove('open');
+            document.getElementById('side-navigation-overlay')?.classList.remove('open');
+            document.body.classList.remove('overflow-hidden');
+            window.scrollHiding.header = true;
+            window.scrollHiding.footer = true;
+            state.open = false;
+        }
+
+        function bind() {
+            const btn = document.getElementById('hamburger');
+            if (!btn || btn.dataset.bound) return;
+            btn.dataset.bound = '1';
+            const state = { open: false };
+
+            btn.addEventListener('click', function () {
+                state.open = !state.open;
+                window.scrollHiding.header = !state.open;
+                window.scrollHiding.footer = !state.open;
+                btn.classList.toggle('open', state.open);
+                btn.setAttribute('aria-expanded', String(state.open));
+                document.getElementById('side-navigation')?.classList.toggle('open', state.open);
+                document.getElementById('side-navigation-overlay')?.classList.toggle('open', state.open);
+                document.body.classList.toggle('overflow-hidden', state.open);
+            });
+
+            document.getElementById('side-navigation-overlay')?.addEventListener('click', () => close(state));
+            document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(state); });
+            document.addEventListener('astro:after-swap', () => close(state));
+        }
+
+        bind();
+        document.addEventListener('astro:after-swap', bind);
     })();
 </script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,7 +5,7 @@ import ThemeToggle from "./ThemeToggle.astro";
 ---
 <header
   transition:persist="header"
-  class="sticky top-0 z-50 transition-[top,background-color,border-color] duration-300 [&.hide]:-top-20
+  class="sticky top-0 z-50 transition-[transform,background-color,border-color] duration-300 ease-out [&.hide]:-translate-y-full
          border-b border-line/70 bg-bg/75 backdrop-blur-md supports-[backdrop-filter]:bg-bg/60"
 >
   <div class="mx-auto flex h-16 max-w-content items-center gap-4 px-5 sm:px-8 lg:px-10">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,20 +1,41 @@
 ---
 import Hamburger from "./Hamburger.astro";
 import NavigationMenu from "./NavigationMenu.astro";
+import ThemeToggle from "./ThemeToggle.astro";
 ---
-<header transition:persist="header" class="flex bg-primary w-screen p-3 h-16 sticky z-50 [&.hide]:-top-16 top-0 transition-[top]">
-  <a href="/"><span class="relative bottom-2 font-display text-5xl text-page mr-8 ml-8 lg:ml-16">mioi.io</span></a>
-  <nav class="w-full">
-    <Hamburger />
-    <NavigationMenu />
-  </nav>
+<header
+  transition:persist="header"
+  class="sticky top-0 z-50 transition-[top,background-color,border-color] duration-300 [&.hide]:-top-20
+         border-b border-line/70 bg-bg/75 backdrop-blur-md supports-[backdrop-filter]:bg-bg/60"
+>
+  <div class="mx-auto flex h-16 max-w-content items-center gap-4 px-5 sm:px-8 lg:px-10">
+    <a href="/" class="group flex items-baseline gap-px font-display text-2xl font-bold tracking-tightest text-ink">
+      <span>mioi</span><span class="text-accent transition-transform duration-300 group-hover:-translate-y-0.5">.</span><span class="text-faint">io</span>
+    </a>
+
+    <div class="ml-auto flex items-center gap-2">
+      <NavigationMenu />
+      <ThemeToggle />
+      <Hamburger />
+    </div>
+  </div>
 </header>
 <script is:inline>
-  (function() {var p = window.scrollY;
-  const h = document.querySelector("header");
-  window.addEventListener("scroll", () => {
-    const c = window.scrollY;
-    if (window.scrollHiding.header) p > c ? h.classList.remove("hide") : h.classList.add("hide");
-    p = c;
-  })})();
+  (function () {
+    function bind() {
+      var h = document.querySelector("header");
+      if (!h || h.dataset.scrollBound) return;
+      h.dataset.scrollBound = "1";
+      var p = window.scrollY;
+      window.addEventListener("scroll", function () {
+        var c = window.scrollY;
+        if (window.scrollHiding && window.scrollHiding.header) {
+          (p > c || c < 80) ? h.classList.remove("hide") : h.classList.add("hide");
+        }
+        p = c;
+      }, { passive: true });
+    }
+    bind();
+    document.addEventListener("astro:after-swap", bind);
+  })();
 </script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -30,7 +30,11 @@ import ThemeToggle from "./ThemeToggle.astro";
       window.addEventListener("scroll", function () {
         var c = window.scrollY;
         if (window.scrollHiding && window.scrollHiding.header) {
-          (p > c || c < 80) ? h.classList.remove("hide") : h.classList.add("hide");
+          var hide = !(p > c || c < 80);
+          h.classList.toggle("hide", hide);
+          // keep the sticky sub-navigation docked to the header as it hides/shows
+          var sub = document.getElementById("sub-nav");
+          if (sub) sub.classList.toggle("header-hidden", hide);
         }
         p = c;
       }, { passive: true });

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,0 +1,105 @@
+---
+import Button from "./Button.astro";
+---
+<section
+    id="hero"
+    class="relative overflow-hidden border-b border-line"
+>
+    <!-- dotted grid + cursor-reactive glow -->
+    <div class="bg-dotgrid pointer-events-none absolute inset-0 opacity-70"></div>
+    <div
+        id="hero-glow"
+        class="pointer-events-none absolute -inset-px opacity-0 transition-opacity duration-500"
+        style="background: radial-gradient(420px circle at var(--mx, 50%) var(--my, 30%), rgb(var(--glow) / 0.14), transparent 70%);"
+    ></div>
+
+    <div class="relative mx-auto max-w-content px-5 pb-20 pt-16 sm:px-8 sm:pt-24 lg:px-10 lg:pb-28">
+        <p class="mb-6 flex items-center gap-3 font-mono text-xs uppercase tracking-widest text-accent" data-reveal>
+            <span class="inline-block h-px w-8 bg-accent"></span>
+            Platform &amp; DevOps Engineer
+        </p>
+
+        <h1
+            class="max-w-4xl font-display text-[2.6rem] font-semibold leading-[1.04] tracking-tightest text-ink sm:text-6xl lg:text-7xl"
+            data-reveal
+        >
+            I build the platforms that turn
+            <span class="relative whitespace-nowrap text-accent">declared&nbsp;intent</span>
+            into running systems.
+        </h1>
+
+        <p class="mt-7 max-w-xl text-lg leading-relaxed text-muted" data-reveal style="--reveal-delay: 80ms">
+            I'm <span class="font-medium text-ink">Tom van Dinther</span> — an IT specialist working in
+            platform engineering, GitOps and type-safe configuration. This is where I keep my projects,
+            writing, and the ideas I'm exploring.
+        </p>
+
+        <!-- terminal-flavoured typed line -->
+        <div
+            class="mt-9 inline-flex max-w-full items-center gap-3 rounded-xl border border-line bg-surface/70 px-4 py-3 font-mono text-sm backdrop-blur"
+            data-reveal
+            style="--reveal-delay: 160ms"
+        >
+            <span class="flex gap-1.5">
+                <span class="h-2.5 w-2.5 rounded-full bg-accent/80"></span>
+                <span class="h-2.5 w-2.5 rounded-full bg-line"></span>
+                <span class="h-2.5 w-2.5 rounded-full bg-line"></span>
+            </span>
+            <span class="text-faint">~</span>
+            <span class="text-muted">$</span>
+            <span id="hero-type" class="text-ink"></span>
+            <span class="inline-block h-4 w-[2px] animate-blink bg-accent align-middle"></span>
+        </div>
+
+        <div class="mt-10 flex flex-wrap items-center gap-3" data-reveal style="--reveal-delay: 240ms">
+            <Button link="/projects" inverted>View Projects</Button>
+            <Button link="/blog">Read Writing</Button>
+        </div>
+    </div>
+</section>
+<script is:inline>
+    (function () {
+        function init() {
+            // cursor-reactive glow
+            var hero = document.getElementById('hero');
+            var glow = document.getElementById('hero-glow');
+            if (hero && glow && !hero.dataset.glowBound && !window.matchMedia('(pointer: coarse)').matches) {
+                hero.dataset.glowBound = '1';
+                hero.addEventListener('pointermove', function (e) {
+                    var r = hero.getBoundingClientRect();
+                    glow.style.setProperty('--mx', (e.clientX - r.left) + 'px');
+                    glow.style.setProperty('--my', (e.clientY - r.top) + 'px');
+                    glow.style.opacity = '1';
+                });
+                hero.addEventListener('pointerleave', function () { glow.style.opacity = '0'; });
+            }
+
+            // typed rotating lines
+            var el = document.getElementById('hero-type');
+            if (!el || el.dataset.typing) return;
+            el.dataset.typing = '1';
+            if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                el.textContent = 'whoami — platform engineer, builder, writer';
+                return;
+            }
+            var lines = [
+                'whoami → tom van dinther',
+                'kubectl apply -f ideas.yaml',
+                'cue vet config.cue && ship it',
+                'cat ~/notes/*.md  # the blog',
+            ];
+            var li = 0, ci = 0, deleting = false;
+            function tick() {
+                var full = lines[li];
+                el.textContent = full.slice(0, ci);
+                if (!deleting && ci < full.length) { ci++; setTimeout(tick, 55); }
+                else if (!deleting && ci === full.length) { deleting = true; setTimeout(tick, 1900); }
+                else if (deleting && ci > 0) { ci--; setTimeout(tick, 26); }
+                else { deleting = false; li = (li + 1) % lines.length; setTimeout(tick, 350); }
+            }
+            tick();
+        }
+        init();
+        document.addEventListener('astro:after-swap', init);
+    })();
+</script>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -1,7 +1,48 @@
 ---
-import Button from "./Button.astro";
+type Props = {
+    variant?: "desktop" | "mobile";
+};
+
+const { variant = "desktop" } = Astro.props;
+
+const links = [
+    { href: "/", label: "Home" },
+    { href: "/projects", label: "Projects" },
+    { href: "/blog", label: "Writing" },
+    { href: "/about", label: "About" },
+];
+
+const path = Astro.url.pathname;
+const isActive = (href: string) =>
+    href === "/" ? path === "/" : path.startsWith(href);
 ---
-<Button link="/" inverted>Home</Button>
-<Button link="/blog" inverted>Blog</Button>
-<Button link="/projects" inverted>Projects</Button>
-<Button link="/about" inverted>About</Button>
+{variant === "desktop" ? (
+    <div class="flex items-center">
+        {links.map((link, i) => (
+            <a
+                href={link.href}
+                aria-current={isActive(link.href) ? "page" : undefined}
+                class={`group relative px-3 py-2 font-mono text-[13px] uppercase tracking-wide transition-colors
+                    ${isActive(link.href) ? "text-accent" : "text-muted hover:text-ink"}`}
+            >
+                <span class="mr-1 text-faint">{String(i + 1).padStart(2, "0")}</span>{link.label}
+                <span class={`pointer-events-none absolute inset-x-3 -bottom-px h-px origin-left bg-accent transition-transform duration-300
+                    ${isActive(link.href) ? "scale-x-100" : "scale-x-0 group-hover:scale-x-100"}`}></span>
+            </a>
+        ))}
+    </div>
+) : (
+    <nav class="flex flex-col">
+        {links.map((link, i) => (
+            <a
+                href={link.href}
+                aria-current={isActive(link.href) ? "page" : undefined}
+                class={`flex items-baseline gap-3 border-b border-line/60 py-4 font-display text-2xl font-semibold tracking-tightest transition-colors
+                    ${isActive(link.href) ? "text-accent" : "text-ink hover:text-accent"}`}
+            >
+                <span class="font-mono text-xs text-faint">{String(i + 1).padStart(2, "0")}</span>
+                {link.label}
+            </a>
+        ))}
+    </nav>
+)}

--- a/src/components/NavigationMenu.astro
+++ b/src/components/NavigationMenu.astro
@@ -2,5 +2,5 @@
 import Navigation from "./Navigation.astro";
 ---
 <div class="hidden lg:flex">
-    <Navigation />
+    <Navigation variant="desktop" />
 </div>

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -1,2 +1,17 @@
-<h1 class="text-3xl my-4"><slot /></h1>
-<hr class="my-4" />
+---
+type Props = {
+    eyebrow?: string;
+    align?: "left" | "center";
+};
+const { eyebrow, align = "left" } = Astro.props;
+---
+<div class={`mb-10 ${align === "center" ? "text-center" : ""}`} data-reveal>
+    {eyebrow && (
+        <p class={`mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-accent ${align === "center" ? "justify-center" : ""}`}>
+            <span class="inline-block h-px w-6 bg-accent"></span>{eyebrow}
+        </p>
+    )}
+    <h1 class="font-display text-4xl font-semibold tracking-tightest text-ink sm:text-5xl">
+        <slot />
+    </h1>
+</div>

--- a/src/components/ProjectItem.astro
+++ b/src/components/ProjectItem.astro
@@ -8,15 +8,39 @@ type Props = {
 const { project } = Astro.props;
 const bannerUrl = project.data.banner?.url ?? project.data.image;
 const bannerAnchor = project.data.banner?.anchor ?? "center top";
+const year = project.data.date.getFullYear();
 ---
-<a href={`/projects/${project.slug}`}>
-    <div class="m-2 shadow-md hover:shadow-lg cursor-pointer overflow-x-clip">
-        {bannerUrl && <div style={`background-image: url(${bannerUrl}); background-position: ${bannerAnchor}`} class="bg-cover h-48 rounded-t-md min-h-[6rem]" />}
-        <div class="py-2 px-4">
-            <h2 class="text-2xl my-2">{project.data.title}</h2>
-            <p class="my-2">
-                {project.data.description}
-            </p>
+<a
+    href={`/projects/${project.slug}`}
+    data-reveal
+    class="group relative flex flex-col overflow-hidden rounded-2xl border border-line bg-surface
+           transition-all duration-300 hover:-translate-y-1 hover:border-accent/50 hover:shadow-[0_18px_40px_-24px_rgb(var(--ink)/0.35)]"
+>
+    {bannerUrl ? (
+        <div class="relative aspect-[16/9] overflow-hidden">
+            <div
+                style={`background-image: url(${bannerUrl}); background-position: ${bannerAnchor}`}
+                class="absolute inset-0 bg-cover bg-no-repeat transition-transform duration-500 group-hover:scale-105"
+            ></div>
+            <div class="absolute inset-0 bg-gradient-to-t from-surface/30 to-transparent"></div>
         </div>
+    ) : (
+        <div class="bg-dotgrid relative aspect-[16/9] overflow-hidden">
+            <span class="absolute bottom-4 left-5 font-display text-3xl font-semibold text-line">{project.data.title}</span>
+        </div>
+    )}
+
+    <div class="flex flex-1 flex-col p-5">
+        <div class="mb-2 flex items-center justify-between gap-3">
+            <h3 class="font-display text-xl font-semibold tracking-tight text-ink transition-colors group-hover:text-accent">
+                {project.data.title}
+            </h3>
+            <span class="shrink-0 font-mono text-xs text-faint">{year}</span>
+        </div>
+        <p class="text-sm leading-relaxed text-muted">{project.data.description}</p>
+        <span class="mt-4 inline-flex items-center gap-1 font-mono text-[12px] uppercase tracking-wide text-accent">
+            View project
+            <span aria-hidden="true" class="transition-transform duration-200 group-hover:translate-x-1">→</span>
+        </span>
     </div>
 </a>

--- a/src/components/ProjectsNavigation.astro
+++ b/src/components/ProjectsNavigation.astro
@@ -1,7 +1,20 @@
 ---
-import Button from './Button.astro';
+const path = Astro.url.pathname;
+const onIndex = path === "/projects" || path === "/projects/";
 ---
-<div class="flex">
-    <Button link="/projects">Projects Home</Button>
-    <Button external link="https://github.com/tvandinther">My GitHub</Button>
-</div>
+<a
+    href="/projects"
+    aria-current={onIndex ? "page" : undefined}
+    class={`whitespace-nowrap rounded-full px-3.5 py-1.5 font-mono text-[12px] uppercase tracking-wide transition-colors
+        ${onIndex ? "bg-ink text-bg" : "text-muted hover:bg-elevated hover:text-ink"}`}
+>
+    All Projects
+</a>
+<a
+    href="https://github.com/tvandinther"
+    target="_blank"
+    rel="noopener"
+    class="ml-auto whitespace-nowrap rounded-full px-3.5 py-1.5 font-mono text-[12px] uppercase tracking-wide text-muted transition-colors hover:text-accent"
+>
+    GitHub ↗
+</a>

--- a/src/components/SideNavigation.astro
+++ b/src/components/SideNavigation.astro
@@ -1,6 +1,16 @@
 ---
 import Navigation from '@components/Navigation.astro'
 ---
-<div id="side-navigation" class="fixed z-40 transition-all [&.open]:right-0 -right-80 w-80 top-0 p-2 pt-[4.5rem] overflow-x-clip overflow-y-auto h-full bg-primary flex flex-col">
-    <Navigation />
+<div
+    id="side-navigation"
+    class="fixed inset-y-0 right-0 z-40 flex w-80 max-w-[85vw] translate-x-full flex-col bg-surface px-6 pb-8 pt-24
+           shadow-2xl transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] [&.open]:translate-x-0"
+>
+    <p class="mb-2 font-mono text-xs uppercase tracking-widest text-faint">Menu</p>
+    <Navigation variant="mobile" />
+    <div class="mt-auto flex gap-4 pt-8 font-mono text-xs uppercase tracking-wide text-muted">
+        <a href="https://github.com/tvandinther" target="_blank" rel="noopener" class="link-underline hover:text-accent">GitHub</a>
+        <a href="https://www.linkedin.com/in/tvandinther/" target="_blank" rel="noopener" class="link-underline hover:text-accent">LinkedIn</a>
+    </div>
 </div>
+<div id="side-navigation-overlay" class="fixed inset-0 z-30 bg-ink/40 opacity-0 backdrop-blur-sm transition-opacity duration-300 [&.open]:opacity-100 pointer-events-none [&.open]:pointer-events-auto"></div>

--- a/src/components/TagPills.astro
+++ b/src/components/TagPills.astro
@@ -6,17 +6,19 @@ type Props = {
 const { tags } = Astro.props;
 
 const results = tags.length > 0 && Array.isArray(tags[0]) ?
-    tags.map(([tagName, tagCount]) => [tagName, `${tagName} (${tagCount})`]) :
-    tags.map(tagName => [tagName, tagName]);
+    (tags as [string, number][]).map(([tagName, tagCount]) => [tagName, `${tagName}`, tagCount] as const) :
+    (tags as string[]).map(tagName => [tagName, tagName, null] as const);
 ---
-<div class="flex flex-wrap">
-    {results.map(([tagName, innerText]) => (
-        <a 
+<div class="flex flex-wrap gap-2">
+    {results.map(([tagName, innerText, count]) => (
+        <a
             transition:name={`tag-${tagName}`}
-            href={`/blog/tags/${tagName}`} 
-            class="inline-block no-underline bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2 hover:bg-gray-300 whitespace-nowrap"
+            href={`/blog/tags/${tagName}`}
+            class="group inline-flex items-center gap-1.5 rounded-full border border-line bg-surface px-3 py-1
+                   font-mono text-[12px] text-muted no-underline transition-colors hover:border-accent hover:text-accent"
         >
-            {innerText}
+            <span class="text-faint transition-colors group-hover:text-accent">#</span>{innerText}
+            {count !== null && <span class="text-faint">{count}</span>}
         </a>
     ))}
 </div>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,37 @@
+---
+// Light/dark toggle. Initial theme is set pre-paint by the inline script in
+// BaseLayout's <head> to avoid a flash of the wrong theme.
+---
+<button
+    id="theme-toggle"
+    type="button"
+    aria-label="Toggle colour theme"
+    title="Toggle theme"
+    class="group relative grid h-9 w-9 place-items-center rounded-full border border-line text-ink/80 transition-colors hover:border-accent hover:text-accent"
+>
+    <!-- sun (shown in dark mode) -->
+    <svg class="absolute h-[18px] w-[18px] scale-0 rotate-90 opacity-0 transition-all duration-300 dark:scale-100 dark:rotate-0 dark:opacity-100" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="4"></circle>
+        <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path>
+    </svg>
+    <!-- moon (shown in light mode) -->
+    <svg class="absolute h-[18px] w-[18px] scale-100 rotate-0 opacity-100 transition-all duration-300 dark:scale-0 dark:-rotate-90 dark:opacity-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+    </svg>
+</button>
+<script is:inline>
+    (function () {
+        function bind() {
+            var btn = document.getElementById('theme-toggle');
+            if (!btn || btn.dataset.bound) return;
+            btn.dataset.bound = '1';
+            btn.addEventListener('click', function () {
+                var dark = document.documentElement.classList.toggle('dark');
+                try { localStorage.setItem('theme', dark ? 'dark' : 'light'); } catch (e) {}
+                document.documentElement.style.setProperty('--theme-color', dark ? '#0d0d10' : '#faf9f6');
+            });
+        }
+        bind();
+        document.addEventListener('astro:after-swap', bind);
+    })();
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -30,16 +30,21 @@ const { pageTitle, description = "Tom van Dinther — IT specialist, platform & 
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
-    <!-- Set theme before paint to avoid a flash of the wrong theme -->
+    <!-- Set theme before paint to avoid a flash of the wrong theme. Runs on
+         first load and re-applies on view transitions (the swap copies the
+         incoming page's <html> attributes, which would otherwise drop .dark). -->
     <script is:inline>
         (function () {
-            try {
-                var stored = localStorage.getItem('theme');
-                var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-                if (stored === 'dark' || (!stored && prefersDark)) {
-                    document.documentElement.classList.add('dark');
-                }
-            } catch (e) {}
+            function applyTheme() {
+                try {
+                    var stored = localStorage.getItem('theme');
+                    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                    var dark = stored === 'dark' || (!stored && prefersDark);
+                    document.documentElement.classList.toggle('dark', dark);
+                } catch (e) {}
+            }
+            applyTheme();
+            document.addEventListener('astro:after-swap', applyTheme);
         })();
     </script>
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,26 +1,51 @@
 ---
 import Header from '@components/Header.astro';
-// import Footer from '@components/Footer.astro';
+import Footer from '@components/Footer.astro';
 import SideNavigation from "@components/SideNavigation.astro";
+import GlobalStyles from "@components/GlobalStyles.astro";
 import { ClientRouter } from 'astro:transitions';
 
 type Props = {
     pageTitle: string;
+    description?: string | undefined;
 }
 
-const { pageTitle } = Astro.props;
+const { pageTitle, description = "Tom van Dinther — IT specialist, platform & DevOps engineer. Projects, writing and ideas." } = Astro.props;
 ---
 <html lang="en">
 <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content={description} />
+    <meta name="theme-color" content="#faf9f6" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0d0d10" media="(prefers-color-scheme: dark)" />
+    <meta name="generator" content={Astro.generator} />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={pageTitle} />
+    <meta property="og:description" content={description} />
+    <meta name="twitter:card" content="summary_large_image" />
+
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Castoro&family=Martian+Mono&family=Poiret+One&display=swap" rel="stylesheet">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#1a202c" />
-    <meta name="generator" content={Astro.generator} />
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+    <!-- Set theme before paint to avoid a flash of the wrong theme -->
+    <script is:inline>
+        (function () {
+            try {
+                var stored = localStorage.getItem('theme');
+                var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                if (stored === 'dark' || (!stored && prefersDark)) {
+                    document.documentElement.classList.add('dark');
+                }
+            } catch (e) {}
+        })();
+    </script>
+
+    <GlobalStyles />
     <slot name="head" />
+
     <!-- Google tag (gtag.js) -->
     <script async type="text/partytown" src="https://www.googletagmanager.com/gtag/js?id=G-8PPBKZ5GD1"></script>
     <script type="text/partytown">
@@ -28,19 +53,48 @@ const { pageTitle } = Astro.props;
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-
     gtag('config', 'G-8PPBKZ5GD1');
     </script>
     <title>{pageTitle}</title>
     <ClientRouter />
 </head>
-<body class="bg-page overflow-x-clip">
-    <Header />
-    <SideNavigation />
-    <slot />
-    <!-- <Footer /> -->
+<body class="min-h-screen overflow-x-clip antialiased">
+    <a href="#main" class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-ink focus:px-4 focus:py-2 focus:text-bg">Skip to content</a>
+    <div class="flex min-h-screen flex-col">
+        <Header />
+        <SideNavigation />
+        <main id="main" class="flex-1">
+            <slot />
+        </main>
+        <Footer />
+    </div>
+
+    <script>
+        window.scrollHiding = { header: true, footer: true };
+    </script>
+
+    <!-- Scroll-reveal observer (re-runs after view transitions) -->
+    <script is:inline>
+        (function () {
+            function setup() {
+                var els = document.querySelectorAll('[data-reveal]:not(.is-visible)');
+                if (!('IntersectionObserver' in window) || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                    els.forEach(function (el) { el.classList.add('is-visible'); });
+                    return;
+                }
+                var io = new IntersectionObserver(function (entries, obs) {
+                    entries.forEach(function (entry) {
+                        if (entry.isIntersecting) {
+                            entry.target.classList.add('is-visible');
+                            obs.unobserve(entry.target);
+                        }
+                    });
+                }, { rootMargin: '0px 0px -8% 0px', threshold: 0.08 });
+                els.forEach(function (el) { io.observe(el); });
+            }
+            setup();
+            document.addEventListener('astro:after-swap', setup);
+        })();
+    </script>
 </body>
-<script>
-    window.scrollHiding = {header: true, footer: true};
-</script>
 </html>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -4,12 +4,13 @@ import PageLayout from "./PageLayout.astro";
 
 type Props = {
     pageTitle: string;
+    description?: string | undefined;
     bannerImage?: string | undefined;
 }
 
-const { pageTitle, bannerImage = "/assets/images/blog_banner.webp" } = Astro.props;
+const { pageTitle, description, bannerImage } = Astro.props;
 ---
-<PageLayout pageTitle={`${pageTitle} — mioi Blog`} bannerImage={bannerImage}>
+<PageLayout pageTitle={`${pageTitle} — mioi`} description={description} bannerImage={bannerImage}>
     <slot name="head" slot="head" />
     <Fragment slot="sub-navigation">
         <BlogNavigation />

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -28,7 +28,7 @@ const hasSubNav = Astro.slots.has('sub-navigation');
     )}
 
     {hasSubNav && (
-        <div id="sub-nav" class="sticky top-16 z-30 border-b border-line/70 bg-bg/80 backdrop-blur-md transition-[top] duration-300 [&.header-hidden]:top-0">
+        <div id="sub-nav" class="sticky top-16 z-30 border-b border-line/70 bg-bg/80 backdrop-blur-md transition-transform duration-300 ease-out [&.header-hidden]:-translate-y-16">
             <div class="mx-auto flex max-w-content items-center gap-1 overflow-x-auto px-5 py-2 sm:px-8 lg:px-10">
                 <slot name="sub-navigation" />
             </div>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -28,7 +28,7 @@ const hasSubNav = Astro.slots.has('sub-navigation');
     )}
 
     {hasSubNav && (
-        <div class="sticky top-16 z-30 border-b border-line/70 bg-bg/80 backdrop-blur-md">
+        <div id="sub-nav" class="sticky top-16 z-30 border-b border-line/70 bg-bg/80 backdrop-blur-md transition-[top] duration-300 [&.header-hidden]:top-0">
             <div class="mx-auto flex max-w-content items-center gap-1 overflow-x-auto px-5 py-2 sm:px-8 lg:px-10">
                 <slot name="sub-navigation" />
             </div>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -4,23 +4,38 @@ import { type Position } from '../types/types';
 
 type Props = {
     pageTitle: string;
-    bannerImage?: string;
+    description?: string | undefined;
+    bannerImage?: string | undefined;
     bannerAlign?: Position | undefined;
 };
 
-const { pageTitle, bannerImage: bannerUrl, bannerAlign = "top" } = Astro.props;
+const { pageTitle, description, bannerImage, bannerAlign = "center" } = Astro.props;
+const hasSubNav = Astro.slots.has('sub-navigation');
 ---
-<BaseLayout pageTitle={pageTitle}>
+<BaseLayout pageTitle={pageTitle} description={description}>
     <slot name="head" slot="head" />
-    <div class="relative flex justify-center w-full overflow-x-clip">
-        {bannerUrl && <div style={`background-image: url(${bannerUrl}); background-position: ${bannerAlign}`} class="relative max-w-4xl h-56 bg-cover w-full" /> }
-        <div class="absolute bottom-0 max-w-4xl p-1 bg-white w-full bg-opacity-40 backdrop-blur border-t border-opacity-50 border-white">
-            <slot name="sub-navigation" />
+
+    {bannerImage && (
+        <div class="mx-auto max-w-content px-5 pt-6 sm:px-8 lg:px-10">
+            <div class="relative h-44 overflow-hidden rounded-2xl border border-line sm:h-60 md:h-72">
+                <div
+                    style={`background-image: url(${bannerImage}); background-position: ${bannerAlign}`}
+                    class="absolute inset-0 scale-105 bg-cover bg-no-repeat"
+                ></div>
+                <div class="absolute inset-0 bg-gradient-to-t from-bg/80 via-bg/10 to-transparent"></div>
+            </div>
         </div>
-    </div>
-    <div id="page" class="px-8 py-4 overflow-y-auto min-h-[calc(100vh-6rem)]">
-        <div class="max-w-4xl m-auto">
-            <slot />
+    )}
+
+    {hasSubNav && (
+        <div class="sticky top-16 z-30 border-b border-line/70 bg-bg/80 backdrop-blur-md">
+            <div class="mx-auto flex max-w-content items-center gap-1 overflow-x-auto px-5 py-2 sm:px-8 lg:px-10">
+                <slot name="sub-navigation" />
+            </div>
         </div>
+    )}
+
+    <div id="page" class="mx-auto w-full max-w-content px-5 py-12 sm:px-8 lg:px-10">
+        <slot />
     </div>
 </BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,64 +1,110 @@
 ---
-import Button from "@components/Button.astro";
 import PageTitle from "@components/PageTitle.astro";
 import PageLayout from "../layouts/PageLayout.astro";
-import {Picture} from 'astro:assets';
-import meImage from "images/me_1.jpeg"
-const pageTitle = "About Me";
+import { Picture } from 'astro:assets';
+import meImage from "images/me_1.jpeg";
+
+const pageTitle = "About — mioi";
+
+const recommendations = [
+  {
+    name: "Viktor Farcic",
+    handle: "DevOps Toolkit",
+    href: "https://www.youtube.com/c/DevOpsToolkit",
+    cta: "YouTube",
+    note: "Every week, a new idea, technology or perspective on DevOps and platform engineering. If you only have 30 minutes a week to stay current in this space, there is no better resource.",
+  },
+  {
+    name: "Dave Farley",
+    handle: "Continuous Delivery",
+    href: "https://www.youtube.com/@ContinuousDelivery",
+    cta: "YouTube",
+    note: "An expert on software delivery and an excellent communicator. No matter which stack you work with, this channel is a must-subscribe.",
+  },
+  {
+    name: "Mark Seemann",
+    handle: "ploeh.dk",
+    href: "https://blog.ploeh.dk/",
+    cta: "Blog",
+    note: "An experienced consultant whose teaching sits at the intersection of C# and functional programming. There are plenty of pearls of wisdom in his blog and talks.",
+  },
+  {
+    name: "Scott Wlaschin",
+    handle: "F# for Fun and Profit",
+    href: "https://fsharpforfunandprofit.com/",
+    cta: "Blog",
+    note: "A massive proponent of F#. His writing on functional programming and domain design is invaluable — even if you never touch F#, it will level up your design.",
+  },
+];
 ---
-<PageLayout pageTitle={pageTitle}>
-  <PageTitle>About</PageTitle>
-  <h2 class="text-2xl">What is mioi?</h2>
-  <p>
-    <strong>mioi</strong> is my personal website. It's a place where I can share my thoughts and projects in my career in software. I may also showcase my various hobbies at mioi as well. <strong>mioi</strong> can be a word or an acronym. I think of it to mean <i>miscellaneous items of interest</i> as a catch-all for the reasons you may be visiting the website.
-  </p>
-  <hr class="my-2" />
-  <h2 class="text-2xl">Who am I?</h2>
-  <p>
-    My name is Tom van Dinther and I work professionally in software. This is a picture of me at the top of a hill in New Zealand where I used to live, but I now live and work in The Netherlands.
-  </p>
-  <Picture src={meImage} alt="Tom van Dinther" class="shadow-md rounded-lg my-2 w-auto h-auto" />
-  <Button link="https://www.linkedin.com/in/tvandinther/">LinkedIn</Button>
-  <Button link="https://www.github.com/tvandinther/">GitHub</Button>
-  <hr class="my-2" />
-  <h2 class="text-2xl">What am I currently working on and learning?</h2>
-  <p>
-    In my profressional day-to-day I work as a consultant, practising DevOps and platform engineering. This involves a lot of bash and YAML. So, to fill my thirst for programming I like to get stuck into Haskell, creating DevOps tools, and the continued development of this website.
-    <br/>
-    <br/>
-    I am also a part of the communities for the CUE and KCL configuration languages. I think that these are an exciting development in the world of platform engineering and you will see plenty of content on my blog about these.
-  </p>
-  <hr class="my-2" />
-  <h2 class="text-2xl">Who do I follow in the tech-sphere?</h2>
-  <p>
-    I have a few favourite YouTube channels and blogs that I follow. I highly recommend each one of them for the topics they cover.
-  </p>
-  <br/>
+<PageLayout pageTitle={pageTitle} description="About Tom van Dinther and the mioi website.">
+  <PageTitle eyebrow="About">Hello, I'm Tom.</PageTitle>
 
-  <h3 class="text-xl">Viktor Farcic (DevOps Toolkit)</h3>
-  <Button link="https://www.youtube.com/c/DevOpsToolkit">YouTube</Button>
-  <p>
-    Every week Viktor releases a new video to his YouTube channel to bring us a new idea, technology, or perspective to the world of DevOps and platform engineering. If you only have 30 minutes per week to stay up-to-date on this space, there is no better resource.
-  </p>
-  <br/>
+  <!-- Intro + portrait -->
+  <div class="grid gap-10 md:grid-cols-[1.4fr_1fr] md:items-start">
+    <div class="space-y-5 text-lg leading-relaxed text-muted" data-reveal>
+      <p>
+        I work professionally in software as a consultant, practising DevOps and platform
+        engineering. I'm currently based in The Netherlands, having moved from New Zealand —
+        where the photo on the right was taken, at the top of a hill I used to call home.
+      </p>
+      <p>
+        Day to day that means a lot of <span class="text-ink">bash and YAML</span>. To scratch the
+        programming itch I get stuck into <span class="text-ink">Haskell</span>, build DevOps tools,
+        and keep developing this website. I'm also active in the
+        <span class="text-ink">CUE</span> and <span class="text-ink">KCL</span> communities — I think
+        type-safe configuration is one of the most exciting developments in platform engineering, and
+        you'll find plenty about it on the blog.
+      </p>
+      <div class="flex flex-wrap gap-3 pt-2">
+        <a href="https://www.linkedin.com/in/tvandinther/" target="_blank" rel="noopener"
+           class="group inline-flex items-center gap-2 rounded-full bg-ink px-4 py-2 font-mono text-[13px] uppercase tracking-wide text-bg transition-colors hover:bg-accent">
+          LinkedIn <span class="transition-transform group-hover:translate-x-1">↗</span>
+        </a>
+        <a href="https://www.github.com/tvandinther/" target="_blank" rel="noopener"
+           class="group inline-flex items-center gap-2 rounded-full border border-line px-4 py-2 font-mono text-[13px] uppercase tracking-wide text-ink transition-colors hover:border-accent hover:text-accent">
+          GitHub <span class="transition-transform group-hover:translate-x-1">↗</span>
+        </a>
+      </div>
+    </div>
 
-  <h3 class="text-xl">Dave Farley (Continuous Delivery)</h3>
-  <Button link="https://www.youtube.com/@ContinuousDelivery">YouTube</Button>
-  <p>
-    Dave Farley is an expert on software delivery and an excellent communicator. His YouTube channel covers all sorts of topics around software development and delivery. No matter which tech stacks you work with, this channel is a must-subscribe.
-  </p>
-  <br/>
-  
-  <h3 class="text-xl">Mark Seemann</h3>
-  <Button link="https://blog.ploeh.dk/">Blog</Button>
-  <p>
-    Mark Seemann is an experienced software consultant. He is a favourite of mine because his teachings are a great intersection of C# and functional programming. There are plenty of pearls of wisdom in his blog and talks he has given which can be found on YouTube.
-  </p>
-  <br/>
-  
-  <h3 class="text-xl">Scott Wlaschin</h3>
-  <Button link="https://fsharpforfunandprofit.com/">Blog</Button>
-  <p>
-    Scott is a software consultant and massive proponent for F#. His blog posts and talks on the topic of functional programming and domain design are invaluable. Even if you don't use F# or functional programming, the learnings from his blog and talks will take your software design to the next level.
-  </p>
+    <figure class="relative" data-reveal style="--reveal-delay: 100ms">
+      <div class="overflow-hidden rounded-2xl border border-line">
+        <Picture src={meImage} alt="Tom van Dinther" class="h-auto w-full" />
+      </div>
+      <figcaption class="mt-3 font-mono text-xs uppercase tracking-wide text-faint">Tom van Dinther · Aotearoa</figcaption>
+    </figure>
+  </div>
+
+  <!-- What is mioi -->
+  <section class="mt-20 border-t border-line pt-12">
+    <h2 class="mb-4 font-display text-2xl font-semibold tracking-tight text-ink" data-reveal>What is mioi?</h2>
+    <p class="max-w-2xl text-lg leading-relaxed text-muted" data-reveal>
+      <span class="text-ink">mioi</span> is my personal website — a place to share my thoughts and
+      projects from a career in software, and the occasional hobby. It can be a word or an acronym;
+      I think of it as <em class="text-ink not-italic">miscellaneous items of interest</em>, a
+      catch-all for whatever reason brought you here.
+    </p>
+  </section>
+
+  <!-- Recommendations -->
+  <section class="mt-20 border-t border-line pt-12">
+    <h2 class="mb-2 font-display text-2xl font-semibold tracking-tight text-ink" data-reveal>People worth following</h2>
+    <p class="mb-8 max-w-2xl text-muted" data-reveal>
+      A few favourites from the tech-sphere. I recommend every one of them for the topics they cover.
+    </p>
+    <div class="grid gap-5 sm:grid-cols-2">
+      {recommendations.map((r) => (
+        <a href={r.href} target="_blank" rel="noopener" data-reveal
+           class="group flex flex-col rounded-2xl border border-line bg-surface p-6 transition-all duration-300 hover:-translate-y-1 hover:border-accent/50">
+          <div class="flex items-baseline justify-between gap-3">
+            <h3 class="font-display text-xl font-semibold tracking-tight text-ink transition-colors group-hover:text-accent">{r.name}</h3>
+            <span class="shrink-0 font-mono text-[11px] uppercase tracking-wide text-faint">{r.cta} ↗</span>
+          </div>
+          <p class="mb-3 font-mono text-xs text-accent">{r.handle}</p>
+          <p class="text-sm leading-relaxed text-muted">{r.note}</p>
+        </a>
+      ))}
+    </div>
+  </section>
 </PageLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,23 +1,29 @@
 ---
 import BlogPostItem from "@components/BlogPostItem.astro";
+import PageTitle from "@components/PageTitle.astro";
 import TagPills from "@components/TagPills.astro";
 import { byLatest } from "@helpers/posts";
 import { getAllTagsCounts } from "@helpers/tags";
 import BlogLayout from "@layouts/BlogLayout.astro";
 import { getCollection } from 'astro:content';
 
-const latestPosts = (await getCollection('blog')).sort(byLatest).slice(0, 5);
-const popularTags = Object.entries((await getAllTagsCounts())).sort((a, b) => a[1] < b[1] ? 1 : -1).slice(0, 10);
+const latestPosts = (await getCollection('blog')).sort(byLatest).slice(0, 6);
+const popularTags = Object.entries((await getAllTagsCounts())).sort((a, b) => b[1] - a[1]).slice(0, 10);
 ---
-<BlogLayout pageTitle="Home">
-  <h1 class="text-3xl my-4">mioi Blog</h1>
-  <p>
-    Welcome to the mioi blog. I like to write about software development and technology. After official documentation, blogs are my favorite way to learn about new technologies and solve problems. When I fail to find information online, and go through the hard yards to find the solution myself, I like to document my learnings in a blog post to save the next person the trouble. As well as instructional posts, I also like to cover topics such as software development techniques, the tools and conceptual ideas.
+<BlogLayout pageTitle="Writing" description="Notes on platform engineering, GitOps, configuration languages and software design.">
+  <PageTitle eyebrow="The Blog">Writing &amp; ideas</PageTitle>
+
+  <p class="-mt-4 mb-12 max-w-2xl text-lg leading-relaxed text-muted" data-reveal>
+    After official documentation, blogs are my favourite way to learn. When I go through the hard
+    yards to solve something myself, I write it down to save the next person the trouble — alongside
+    posts on software techniques, tooling, and the ideas behind them.
   </p>
-  <h2 class="text-2xl my-4">Latest Posts</h2>
-  <div class="flex flex-col">
+
+  <h2 class="mb-4 font-mono text-xs uppercase tracking-widest text-faint" data-reveal>Latest posts</h2>
+  <div class="mb-14 flex flex-col gap-1">
     {latestPosts.map(post => <BlogPostItem post={post} />)}
   </div>
-  <h2 class="text-2xl my-4">Popular Tags</h2>
-  <TagPills tags={popularTags} />
+
+  <h2 class="mb-4 font-mono text-xs uppercase tracking-widest text-faint" data-reveal>Popular tags</h2>
+  <div data-reveal><TagPills tags={popularTags} /></div>
 </BlogLayout>

--- a/src/pages/blog/posts/[slug].astro
+++ b/src/pages/blog/posts/[slug].astro
@@ -4,11 +4,12 @@ import type { CollectionEntry } from "astro:content";
 import BlogLayout from "@layouts/BlogLayout.astro";
 import TagPills from "@components/TagPills.astro";
 import { getPostBanner } from "@helpers/posts";
+import "@helpers/utility";
 
 export async function getStaticPaths() {
     const allPosts = await getCollection("blog");
     return allPosts.map((post) => ({
-        params: { slug: post.slug }, props: { post } 
+        params: { slug: post.slug }, props: { post }
     }));
 }
 
@@ -18,21 +19,40 @@ type Props = {
 
 const { post } = Astro.props;
 const { Content } = await post.render();
+const banner = post.data.image?.url ?? await getPostBanner(post);
 ---
-<BlogLayout pageTitle={post.data.title} bannerImage={post.data.image?.url ?? await getPostBanner(post)} >
-    <Fragment slot="head" >
+<BlogLayout pageTitle={post.data.title} description={post.data.description} bannerImage={banner}>
+    <Fragment slot="head">
         <meta property="og:title" content={post.data.title} />
         <meta property="og:description" content={post.data.description} />
+        <meta property="og:image" content={banner} />
     </Fragment>
-    <article class="my-8 w-full max-w-3xl m-auto prose lg:prose-lg prose-stone font-body">
-        <h1 transition:name={`title-${post.slug}`} class="text-4xl">{post.data.title}</h1>
-        <address class="text-lg italic">Written by {post.data.author}</address>
-        <time datetime={post.data.date.toString()}>{post.data.date.toFormattedDateString()}</time>
-        {post.data.lastUpdated && (
-            <p class="text-sm text-gray-500">Last updated: {post.data.lastUpdated.toFormattedDateString()}</p>
-        )}
-        <TagPills tags={post.data.tags} />
-        <Content />
+
+    <article class="mx-auto max-w-3xl">
+        <header class="mb-10 border-b border-line pb-8">
+            <div class="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-xs uppercase tracking-wide text-faint">
+                <time datetime={post.data.date.toString()}>{post.data.date.toFormattedDateString()}</time>
+                <span class="text-line">·</span>
+                <span>{post.data.author}</span>
+                {post.data.lastUpdated && (
+                    <><span class="text-line">·</span><span>Updated {post.data.lastUpdated.toFormattedDateString()}</span></>
+                )}
+            </div>
+            <h1 transition:name={`title-${post.slug}`} class="font-display text-4xl font-semibold leading-[1.08] tracking-tightest text-ink sm:text-5xl">
+                {post.data.title}
+            </h1>
+            <p class="mt-5 text-lg leading-relaxed text-muted">{post.data.description}</p>
+            <div class="mt-6"><TagPills tags={post.data.tags} /></div>
+        </header>
+
+        <div class="prose prose-mioi lg:prose-lg">
+            <Content />
+        </div>
+
+        <footer class="mt-16 border-t border-line pt-8">
+            <a href="/blog/posts" class="group inline-flex items-center gap-2 font-mono text-sm uppercase tracking-wide text-muted transition-colors hover:text-accent">
+                <span aria-hidden="true" class="transition-transform group-hover:-translate-x-1">←</span> All posts
+            </a>
+        </footer>
     </article>
 </BlogLayout>
-  

--- a/src/pages/blog/posts/[slug].astro
+++ b/src/pages/blog/posts/[slug].astro
@@ -45,7 +45,7 @@ const banner = post.data.image?.url ?? await getPostBanner(post);
             <div class="mt-6"><TagPills tags={post.data.tags} /></div>
         </header>
 
-        <div class="prose prose-mioi lg:prose-lg">
+        <div class="prose prose-mioi break-words lg:prose-lg">
             <Content />
         </div>
 

--- a/src/pages/blog/posts/index.astro
+++ b/src/pages/blog/posts/index.astro
@@ -2,12 +2,13 @@
 import BlogLayout from "@layouts/BlogLayout.astro";
 import { getCollection } from 'astro:content';
 import BlogPostItem from "@components/BlogPostItem.astro";
+import PageTitle from "@components/PageTitle.astro";
 import { byLatest } from "@helpers/posts";
-const allPosts = await getCollection('blog');
+const allPosts = (await getCollection('blog')).sort(byLatest);
 ---
-<BlogLayout pageTitle="All Posts">
-    <h1 class="text-3xl my-4">All Posts</h1>
-    <div class="flex flex-col">
-        {allPosts.sort(byLatest).map(post => <BlogPostItem post={post} />)}
+<BlogLayout pageTitle="All Posts" description="Every post on the mioi blog.">
+    <PageTitle eyebrow={`${allPosts.length} posts`}>All Posts</PageTitle>
+    <div class="flex flex-col gap-1">
+        {allPosts.map(post => <BlogPostItem post={post} />)}
     </div>
 </BlogLayout>

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -26,9 +26,16 @@ type Props = {
 const { tag } = Astro.params;
 const { posts } = Astro.props;
 ---
-<BlogLayout pageTitle={tag ?? ""}>
-    <h1 class="text-3xl my-4">Posts tagged with <span transition:name=`tag-${tag}` class="bg-gray-200 rounded-full px-3 py-1 text-lg font-semibold text-gray-700 mr-2 mb-2 whitespace-pre">{tag}</span></h1>
-    <ul>
+<BlogLayout pageTitle={`#${tag}`} description={`Posts tagged ${tag}.`}>
+    <div class="mb-10" data-reveal>
+        <p class="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-accent">
+            <span class="inline-block h-px w-6 bg-accent"></span>{posts.length} {posts.length === 1 ? "post" : "posts"}
+        </p>
+        <h1 class="font-display text-4xl font-semibold tracking-tightest text-ink sm:text-5xl">
+            <span class="text-faint">#</span><span transition:name={`tag-${tag}`}>{tag}</span>
+        </h1>
+    </div>
+    <div class="flex flex-col gap-1">
       {posts.map((post) => <BlogPostItem post={post} />)}
-    </ul>
+    </div>
 </BlogLayout>

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -1,10 +1,12 @@
 ---
+import PageTitle from "@components/PageTitle.astro";
 import TagPills from "@components/TagPills.astro";
 import { getAllTagsCounts } from "@helpers/tags";
 import BlogLayout from "@layouts/BlogLayout.astro";
 const tagCounts = await getAllTagsCounts();
+const sorted = Object.entries(tagCounts).sort(([, a], [, b]) => b - a);
 ---
-<BlogLayout pageTitle="Tags">
-  <h1 class="text-3xl my-4">All Tags</h1>
-  <TagPills tags={Object.entries(tagCounts).toSorted(([, aCount], [, bCount]) => bCount - aCount)} />
+<BlogLayout pageTitle="Tags" description="Browse blog posts by topic.">
+  <PageTitle eyebrow={`${sorted.length} topics`}>Browse by tag</PageTitle>
+  <div data-reveal><TagPills tags={sorted} /></div>
 </BlogLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,27 +1,93 @@
 ---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import Hero from "@components/Hero.astro";
 import BlogPostItem from "@components/BlogPostItem.astro";
-import Button from "@components/Button.astro";
-import PageTitle from "@components/PageTitle.astro";
 import ProjectItem from "@components/ProjectItem.astro";
 import { byLatest as byLatestPost } from "@helpers/posts";
 import { byLatest as byLatestProject } from "@helpers/projects";
 import { getCollection } from "astro:content";
-import PageLayout from "../layouts/PageLayout.astro";
-const pageTitle = "mioi";
-const featuredPosts = (await getCollection("blog")).filter((post) => post.data.featured).sort(byLatestPost);
-const featuredProjects = (await getCollection("projects")).filter((post) => post.data.featured).sort(byLatestProject);
+
+const pageTitle = "mioi — Tom van Dinther";
+const featuredProjects = (await getCollection("projects")).filter((p) => p.data.featured).sort(byLatestProject).slice(0, 4);
+const featuredPosts = (await getCollection("blog")).filter((p) => p.data.featured).sort(byLatestPost).slice(0, 4);
+
+const toolbelt = [
+  "Kubernetes", "GitOps", "ArgoCD", "Crossplane", "CUE", "KCL",
+  "Terraform", "Docker", "Haskell", "F#", "Bash", "CI/CD",
+];
 ---
-<PageLayout pageTitle={pageTitle}>
-  <PageTitle>Featured Projects</PageTitle>
-  <div class="flex flex-col">
-    {featuredProjects.map((project) => (
-      <ProjectItem project={project} />
-    ))}
-  </div>
-  <Button link="/projects">All Projects 〉</Button>
-  <PageTitle>Featured Blog Posts</PageTitle>
-  {featuredPosts.map((post) => (
-    <BlogPostItem post={post} />
-  ))}
-  <Button link="/blog">All Blog Posts 〉</Button>
-</PageLayout>
+<BaseLayout pageTitle={pageTitle}>
+  <Hero />
+
+  <!-- Selected work -->
+  <section class="mx-auto max-w-content px-5 py-20 sm:px-8 lg:px-10">
+    <div class="mb-10 flex flex-wrap items-end justify-between gap-4" data-reveal>
+      <div>
+        <p class="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-accent">
+          <span class="inline-block h-px w-6 bg-accent"></span>Selected Work
+        </p>
+        <h2 class="font-display text-3xl font-semibold tracking-tightest text-ink sm:text-4xl">Projects &amp; tools I've built</h2>
+      </div>
+      <a href="/projects" class="link-underline font-mono text-sm uppercase tracking-wide text-muted hover:text-accent">All projects →</a>
+    </div>
+
+    <div class="grid gap-5 sm:grid-cols-2">
+      {featuredProjects.map((project) => <ProjectItem project={project} />)}
+    </div>
+  </section>
+
+  <!-- Toolbelt strip -->
+  <section class="border-y border-line bg-surface/40">
+    <div class="mx-auto max-w-content px-5 py-12 sm:px-8 lg:px-10">
+      <div class="flex flex-col gap-6 md:flex-row md:items-center md:gap-10">
+        <p class="shrink-0 font-mono text-xs uppercase tracking-widest text-faint" data-reveal>
+          Things I<br class="hidden md:block" /> work with
+        </p>
+        <div class="flex flex-wrap gap-2.5" data-reveal style="--reveal-delay: 80ms">
+          {toolbelt.map((t) => (
+            <span class="rounded-full border border-line px-3.5 py-1.5 font-mono text-[13px] text-muted transition-colors hover:border-accent hover:text-accent">{t}</span>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Recent writing -->
+  <section class="mx-auto max-w-content px-5 py-20 sm:px-8 lg:px-10">
+    <div class="mb-8 flex flex-wrap items-end justify-between gap-4" data-reveal>
+      <div>
+        <p class="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-accent">
+          <span class="inline-block h-px w-6 bg-accent"></span>From the Blog
+        </p>
+        <h2 class="font-display text-3xl font-semibold tracking-tightest text-ink sm:text-4xl">Writing &amp; ideas</h2>
+      </div>
+      <a href="/blog" class="link-underline font-mono text-sm uppercase tracking-wide text-muted hover:text-accent">All posts →</a>
+    </div>
+
+    <div class="flex flex-col gap-1">
+      {featuredPosts.map((post) => <BlogPostItem post={post} />)}
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="mx-auto max-w-content px-5 pb-8 sm:px-8 lg:px-10">
+    <div class="bg-dotgrid relative overflow-hidden rounded-2xl border border-line px-8 py-14 text-center" data-reveal>
+      <h2 class="mx-auto max-w-2xl font-display text-3xl font-semibold tracking-tightest text-ink sm:text-4xl">
+        Let's build something that lasts.
+      </h2>
+      <p class="mx-auto mt-4 max-w-xl text-muted">
+        I'm always happy to talk platforms, configuration languages, and developer experience.
+      </p>
+      <div class="mt-8 flex flex-wrap justify-center gap-3">
+        <a href="https://www.linkedin.com/in/tvandinther/" target="_blank" rel="noopener"
+           class="group inline-flex items-center gap-2 rounded-full bg-ink px-5 py-2.5 font-mono text-[13px] uppercase tracking-wide text-bg transition-colors hover:bg-accent">
+          Connect on LinkedIn <span class="transition-transform group-hover:translate-x-1">↗</span>
+        </a>
+        <a href="/about"
+           class="group inline-flex items-center gap-2 rounded-full border border-line px-5 py-2.5 font-mono text-[13px] uppercase tracking-wide text-ink transition-colors hover:border-accent hover:text-accent">
+          More about me <span class="transition-transform group-hover:translate-x-1">→</span>
+        </a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -2,8 +2,6 @@
 import { getCollection } from "astro:content";
 import type { CollectionEntry } from "astro:content";
 import PageLayout from "@layouts/PageLayout.astro";
-import PageTitle from "@components/PageTitle.astro";
-import Button from "@components/Button.astro";
 import ProjectsNavigation from "@components/ProjectsNavigation.astro";
 
 export async function getStaticPaths() {
@@ -19,21 +17,61 @@ type Props = {
 
 const { project } = Astro.props;
 const { Content } = await project.render();
+const banner = project.data.banner?.url ?? project.data.image;
 ---
-<PageLayout pageTitle="Egg Inc. Companion App" 
-    bannerImage={project.data.banner?.url ?? "/assets/images/projects_banner.webp"}
+<PageLayout
+    pageTitle={`${project.data.title} — mioi`}
+    description={project.data.description}
+    bannerImage={banner}
     bannerAlign={project.data.banner?.anchor}
 >
+    <Fragment slot="head">
+        <meta property="og:title" content={project.data.title} />
+        <meta property="og:description" content={project.data.description} />
+        {banner && <meta property="og:image" content={banner} />}
+    </Fragment>
     <Fragment slot="sub-navigation">
         <ProjectsNavigation />
     </Fragment>
-    <PageTitle>{project.data.title}</PageTitle>
-    {project.data.image && <img src={project.data.image} class="m-auto w-full h-auto shadow-sm border-2 rounded border-gray-300">}
-    <div class="flex mb-2">
-        {project.data.url && <Button external link={project.data.url}>Go to site</Button>}
-        {project.data.sourceCodeUrl && <Button external link={project.data.sourceCodeUrl}>Source code</Button>}
-    </div>
-    <div class="prose-lg lg:prose-2xl prose-stone">
-        <Content />
-    </div>    
+
+    <article class="mx-auto max-w-3xl">
+        <header class="mb-10 border-b border-line pb-8">
+            <p class="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-accent">
+                <span class="inline-block h-px w-6 bg-accent"></span>Project · {project.data.date.getFullYear()}
+            </p>
+            <h1 class="font-display text-4xl font-semibold leading-[1.08] tracking-tightest text-ink sm:text-5xl">
+                {project.data.title}
+            </h1>
+            <p class="mt-5 text-lg leading-relaxed text-muted">{project.data.description}</p>
+
+            <div class="mt-6 flex flex-wrap gap-3">
+                {project.data.url && (
+                    <a href={project.data.url} target="_blank" rel="noopener"
+                       class="group inline-flex items-center gap-2 rounded-full bg-ink px-4 py-2 font-mono text-[13px] uppercase tracking-wide text-bg transition-colors hover:bg-accent">
+                        Visit site <span class="transition-transform group-hover:translate-x-1">↗</span>
+                    </a>
+                )}
+                {project.data.sourceCodeUrl && (
+                    <a href={project.data.sourceCodeUrl} target="_blank" rel="noopener"
+                       class="group inline-flex items-center gap-2 rounded-full border border-line px-4 py-2 font-mono text-[13px] uppercase tracking-wide text-ink transition-colors hover:border-accent hover:text-accent">
+                        Source code <span class="transition-transform group-hover:translate-x-1">↗</span>
+                    </a>
+                )}
+            </div>
+        </header>
+
+        {project.data.image && (
+            <img src={project.data.image} alt={project.data.title} class="mb-10 w-full rounded-xl border border-line" />
+        )}
+
+        <div class="prose prose-mioi lg:prose-lg">
+            <Content />
+        </div>
+
+        <footer class="mt-16 border-t border-line pt-8">
+            <a href="/projects" class="group inline-flex items-center gap-2 font-mono text-sm uppercase tracking-wide text-muted transition-colors hover:text-accent">
+                <span aria-hidden="true" class="transition-transform group-hover:-translate-x-1">←</span> All projects
+            </a>
+        </footer>
+    </article>
 </PageLayout>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -64,7 +64,7 @@ const banner = project.data.banner?.url ?? project.data.image;
             <img src={project.data.image} alt={project.data.title} class="mb-10 w-full rounded-xl border border-line" />
         )}
 
-        <div class="prose prose-mioi lg:prose-lg">
+        <div class="prose prose-mioi break-words lg:prose-lg">
             <Content />
         </div>
 

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -3,18 +3,21 @@ import PageTitle from "@components/PageTitle.astro";
 import ProjectItem from "@components/ProjectItem.astro";
 import ProjectsNavigation from "@components/ProjectsNavigation.astro";
 import PageLayout from "@layouts/PageLayout.astro";
+import { byLatest } from "@helpers/projects";
 import { getCollection } from "astro:content";
 
-const allProjects = await getCollection("projects");
+const allProjects = (await getCollection("projects")).sort(byLatest);
 ---
-<PageLayout pageTitle="Projects — mioi" bannerImage="/assets/images/projects_banner.webp">
+<PageLayout pageTitle="Projects — mioi" description="Tools, apps and experiments built by Tom van Dinther.">
     <Fragment slot="sub-navigation">
         <ProjectsNavigation />
     </Fragment>
-    <PageTitle>Projects</PageTitle>
-    <div class="flex flex-col">
-        {allProjects.sort((a, b) => a.data.date < b.data.date ? 1 : -1).map(project =>
-        <ProjectItem project={project} />
-        )}
+    <PageTitle eyebrow="Selected Work">Projects</PageTitle>
+    <p class="-mt-4 mb-12 max-w-2xl text-lg leading-relaxed text-muted" data-reveal>
+        A collection of the tools, applications and experiments I've built — from platform engineering
+        utilities to side projects I made for fun.
+    </p>
+    <div class="grid gap-5 sm:grid-cols-2">
+        {allProjects.map(project => <ProjectItem project={project} />)}
     </div>
 </PageLayout>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,56 +1,130 @@
 /** @type {import('tailwindcss').Config} */
 const defaultTheme = require('tailwindcss/defaultTheme');
 
+/** Semantic colours are driven by CSS variables (see GlobalStyles.astro) so a
+ *  single class toggle flips the entire palette between light and dark. The
+ *  variables hold space-separated RGB channels so Tailwind's <alpha-value>
+ *  opacity modifiers keep working. */
+const withVar = (name) => `rgb(var(${name}) / <alpha-value>)`;
+/** Solid colour reference (no alpha placeholder) for arbitrary CSS values. */
+const solid = (name) => `rgb(var(${name}))`;
+
+const sans = ['"Inter"', ...defaultTheme.fontFamily.sans].join(', ');
+const display = ['"Space Grotesk"', ...defaultTheme.fontFamily.sans].join(', ');
+
 module.exports = {
+	darkMode: 'class',
 	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
 	theme: {
 		extend: {
-			// fontFamily: {
-			// 	'display': ['"Poiret One"', ...defaultTheme.fontFamily.sans],
-			// },
 			gridTemplateRows: {
 				'layout': 'auto 1fr auto',
 			},
 			colors: {
-				'primary': '#323c73',
-				'secondary': '#2d3748',
-				'tertiary': '#4a5568',
-				'accent': '#ed8936',
-				'accent-light': '#f6ad55',
-				'accent-dark': '#dd6b20',
-				'page': '#ffffff',
+				'bg': withVar('--bg'),
+				'surface': withVar('--surface'),
+				'elevated': withVar('--elevated'),
+				'ink': withVar('--ink'),
+				'muted': withVar('--muted'),
+				'faint': withVar('--faint'),
+				'line': withVar('--line'),
+				'accent': withVar('--accent'),
+				'accent-soft': withVar('--accent-soft'),
+				// legacy aliases kept mapped so stray references don't break
+				'page': withVar('--bg'),
+				'primary': withVar('--ink'),
 			},
-			typography: theme => ({
-				DEFAULT: {
+			fontFamily: {
+				'display': ['"Space Grotesk"', ...defaultTheme.fontFamily.sans],
+				'sans': ['"Inter"', ...defaultTheme.fontFamily.sans],
+				'body': ['"Inter"', ...defaultTheme.fontFamily.sans],
+				'mono': ['"JetBrains Mono"', ...defaultTheme.fontFamily.mono],
+			},
+			letterSpacing: {
+				'tightest': '-0.04em',
+			},
+			maxWidth: {
+				'content': '72rem',
+			},
+			keyframes: {
+				'fade-up': {
+					'0%': { opacity: '0', transform: 'translateY(14px)' },
+					'100%': { opacity: '1', transform: 'translateY(0)' },
+				},
+				'blink': {
+					'0%, 100%': { opacity: '1' },
+					'50%': { opacity: '0' },
+				},
+				'float-slow': {
+					'0%, 100%': { transform: 'translate(0, 0)' },
+					'50%': { transform: 'translate(0, -10px)' },
+				},
+			},
+			animation: {
+				'fade-up': 'fade-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both',
+				'blink': 'blink 1.1s step-end infinite',
+				'float-slow': 'float-slow 7s ease-in-out infinite',
+			},
+			typography: () => ({
+				mioi: {
 					css: {
-						'code::before': {
-							content: 'none',
+						'--tw-prose-body': solid('--ink'),
+						'--tw-prose-headings': solid('--ink'),
+						'--tw-prose-links': solid('--accent'),
+						'--tw-prose-bold': solid('--ink'),
+						'--tw-prose-counters': solid('--muted'),
+						'--tw-prose-bullets': solid('--line'),
+						'--tw-prose-hr': solid('--line'),
+						'--tw-prose-quotes': solid('--muted'),
+						'--tw-prose-quote-borders': solid('--accent'),
+						'--tw-prose-captions': solid('--muted'),
+						'--tw-prose-code': solid('--ink'),
+						'--tw-prose-pre-code': '#e6e6e6',
+						'--tw-prose-pre-bg': '#161618',
+						'--tw-prose-th-borders': solid('--line'),
+						'--tw-prose-td-borders': solid('--line'),
+						maxWidth: 'none',
+						fontFamily: sans,
+						h1: { fontFamily: display, letterSpacing: '-0.03em', fontWeight: '600' },
+						h2: { fontFamily: display, letterSpacing: '-0.02em', fontWeight: '600' },
+						h3: { fontFamily: display, letterSpacing: '-0.01em', fontWeight: '600' },
+						h4: { fontFamily: display, fontWeight: '600' },
+						a: {
+							textDecoration: 'none',
+							borderBottom: `1px solid ${solid('--accent-soft')}`,
+							transition: 'border-color 0.2s ease',
 						},
-						'code::after': {
-							content: 'none',
+						'a:hover': { borderBottomColor: solid('--accent') },
+						'code::before': { content: 'none' },
+						'code::after': { content: 'none' },
+						code: {
+							color: solid('--accent'),
+							backgroundColor: solid('--accent-wash'),
+							borderRadius: '0.3rem',
+							padding: '0.15em 0.4em',
+							fontWeight: '500',
+							fontSize: '0.875em',
 						},
-						'code': {
-							color: '#942d00',
-							backgroundColor: '#fff2eb',
-							borderRadius: '0.25rem',
+						pre: {
+							borderRadius: '0.6rem',
+							border: `1px solid ${solid('--line')}`,
 						},
 						blockquote: {
-							quotes: "none"
-						}
-					}
-				}
-			})
-		},
-		fontFamily: {
-			'display': ['"Poiret One"', ...defaultTheme.fontFamily.sans],
-			'body': ['"Castoro"', ...defaultTheme.fontFamily.serif],
-			// 'mono': ['"Martian Mono"', ...defaultTheme.fontFamily.mono],
+							quotes: 'none',
+							fontStyle: 'normal',
+							fontWeight: '400',
+							borderLeftWidth: '2px',
+							paddingLeft: '1.25rem',
+						},
+					},
+				},
+			}),
 		},
 	},
 	plugins: [
 		require('@tailwindcss/typography'),
 		function ({ addVariant }) {
 			addVariant('child', '& > *');
-		}
+		},
 	],
-}
+};


### PR DESCRIPTION
Reworks the entire front-end into a clean, editorial design that better
showcases Tom's work and ideas as an IT specialist.

Design system
- New type stack: Space Grotesk (display), Inter (body), JetBrains Mono
  (metadata/labels) for strong typographic hierarchy.
- Semantic, CSS-variable colour tokens (paper/ink + single vermilion accent)
  driving a full light/dark theme via a single class toggle.
- Refined prose theme (prose-mioi), custom scrollbar, selection, dot-grid.

Interactive flourishes (subtle, reduced-motion aware)
- Light/dark theme toggle with no flash of wrong theme and system preference.
- Scroll-reveal fade-ups via IntersectionObserver.
- Hero with cursor-reactive glow and a typed terminal line.
- Card hover lifts, animated link underlines, arrow nudges.

Layout & pages
- Minimal sticky header with numbered nav + active states; new footer;
  smoother mobile slide-in menu with overlay.
- New homepage: hero, selected-work grid, toolbelt strip, writing list, CTA.
- Editorial blog list rows, refined project cards, tab-style sub-navigation.
- Rebuilt blog/post, projects/project, tags and about pages.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0168yw7Vg5iRK3uxX5XPYoxy